### PR TITLE
fix: single query trans failed missing prefix

### DIFF
--- a/manga_translator/translators/config_gpt.py
+++ b/manga_translator/translators/config_gpt.py
@@ -57,6 +57,7 @@ class ConfigGPT:
         '- Output each segment with its prefix (<|number|> format exactly).\n'  
         '- Translate content only—no additional interpretation or commentary.\n'  
         '- Do not include any explanations, analysis, or commentary on the original text or the translation.\n'
+        '- Always prefix each of your translations with the tag "<|N|>" where N is the number of the query. For example, start your first translation with "<|1|>", the second with "<|2|>", and so on. Even when there is only one query, prefix it with "<|1|>".\n'
         
         'Translate the following text into {to_lang}:\n'  
     )

--- a/manga_translator/translators/config_gpt.py
+++ b/manga_translator/translators/config_gpt.py
@@ -57,6 +57,7 @@ class ConfigGPT:
         '- Output each segment with its prefix (<|number|> format exactly).\n'  
         '- Translate content only—no additional interpretation or commentary.\n'  
         '- Do not include any explanations, analysis, or commentary on the original text or the translation.\n'
+        
         'Translate the following text into {to_lang}:\n'  
     )
   

--- a/manga_translator/translators/config_gpt.py
+++ b/manga_translator/translators/config_gpt.py
@@ -57,8 +57,6 @@ class ConfigGPT:
         '- Output each segment with its prefix (<|number|> format exactly).\n'  
         '- Translate content only—no additional interpretation or commentary.\n'  
         '- Do not include any explanations, analysis, or commentary on the original text or the translation.\n'
-        '- Always prefix each of your translations with the tag "<|N|>" where N is the number of the query. For example, start your first translation with "<|1|>", the second with "<|2|>", and so on. Even when there is only one query, prefix it with "<|1|>".\n'
-        
         'Translate the following text into {to_lang}:\n'  
     )
   

--- a/manga_translator/translators/custom_openai.py
+++ b/manga_translator/translators/custom_openai.py
@@ -199,7 +199,7 @@ class CustomOpenAiTranslator(ConfigGPT, CommonTranslator):
             translations.extend([t.strip() for t in new_translations])
 
         for t in translations:
-            if "I'm sorry, but I can't assist with that request" in t:
+            if "I'm sorry, but I can't assist with that" in t:
                 raise Exception('translations contain error text')
         self.logger.debug(translations)
         if self.token_count_last:


### PR DESCRIPTION
Sentry Issue

https://ismanga.sentry.io/issues/6537022250/events/2be6fc0712a946689c5c447af468f89a/?project=4504443314110464

This happening because inconsistent response from chatGPT, I don't know about others, in our case, 

instead of ChatGPT responding with "I'm sorry, but I can't assist with that request"
it was responding with " I'm sorry, but I can't assist with that."

so, the request part was missing, and this error was slipping through the error detection and causing the prefix error since error messages won't have <|1|> prefixes 

Screenshot 

<img width="1144" alt="Screenshot 2025-05-18 at 7 28 19 PM" src="https://github.com/user-attachments/assets/d5a5a429-5c55-4bcf-a1b6-07b22362a900" />


I am not sure how changing this may affect other things so I will continue with testing